### PR TITLE
Use default cache for node workflows

### DIFF
--- a/.github/workflows/sonar-npm.yml
+++ b/.github/workflows/sonar-npm.yml
@@ -28,22 +28,9 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ inputs.node_version }}
-          cache: 'npm'
-      - name: Cache node modules
-        id: cache-nodemodules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          cache: "npm"
       - name: Install dependencies
-        if: steps.cache-nodemodules.outputs.cache-hit != 'true' || github.ref_name == 'master'
-        run: npm install --unsafe-perm
+        run: npm install
       - name: Lint
         run: npm run lint
       - name: Test


### PR DESCRIPTION
Following up on https://github.com/leanspace/workflows/pull/1/files#r844071642 — the default caching behavior should be fine for most npm based packages :)