### PR TITLE
Trigger jenkins pipeline pending run bug

### DIFF
--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -22,7 +22,7 @@ jobs:
           JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN }}
           JENKINS_USER: ${{ secrets.JENKINS_USER }}
           PARAMETER_NAME: ${{ inputs.param }}
-        run: "curl -X POST --user \"$JENKINS_USER:$JENKINS_TOKEN\" \
+        run: "curl -X POST --user \"$JENKINS_USER\" \
           'https://build.leanspace.io/jenkins/job/leanspace/job/leanspace-infra/job/master/buildWithParameters' \
           -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode \
-          \"$PARAMETER_NAME=$ARTIFACT_IDENTIFIER\""
+          \"$PARAMETER_NAME=$ARTIFACT_IDENTIFIER\" --fail-with-body"

--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -17,12 +17,12 @@ jobs:
       - name: Set env
         run: echo "ARTIFACT_IDENTIFIER=0.1.${GITHUB_RUN_NUMBER}_${GITHUB_RUN_ATTEMPT}_${GITHUB_SHA:0:7}" >> $GITHUB_ENV
       - name: Trigger jenkins infra script
-        # if: github.ref_name == 'master'
+        if: github.ref_name == 'master'
         env:
           JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN }}
           JENKINS_USER: ${{ secrets.JENKINS_USER }}
           PARAMETER_NAME: ${{ inputs.param }}
-        run: "curl -v -X POST --user \"$JENKINS_USER:$JENKINS_TOKEN\" \
+        run: "curl -X POST --user \"$JENKINS_USER:$JENKINS_TOKEN\" \
           'https://build.leanspace.io/jenkins/job/leanspace/job/leanspace-infra/job/master/buildWithParameters' \
           -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode \
           \"$PARAMETER_NAME=$ARTIFACT_IDENTIFIER\""

--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -19,13 +19,10 @@ jobs:
       - name: Trigger jenkins infra script
         if: github.ref_name == 'master'
         uses: toptal/jenkins-job-trigger-action@master
-        with:
-          jenkins_url: "https://build.leanspace.io/jenkins/"
-          jenkins_user: ${{ secrets.JENKINS_USER }}
-          jenkins_token: ${{ secrets.JENKINS_TOKEN }}
-          job_name: "leanspace/job/leanspace-infra/job/master"
-          job_params: |
-            {
-              "${{ inputs.param }}" : "${{ env.ARTIFACT_IDENTIFIER }}"
-            }
-          async: true
+        env:
+          JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN }}
+          PARAMETER_NAME: ${{ inputs.param }}
+        run: "curl --location --request POST 'https://build.leanspace.io/jenkins/job/leanspace/job/leanspace-infra/job/master/buildWithParameters' \
+          --header 'Authorization: Basic $JENKINS_TOKEN' \
+          --header 'Content-Type: application/x-www-form-urlencoded' \
+          --data-urlencode '$PARAMETER_NAME=$ARTIFACT_IDENTIFIER'"

--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -18,11 +18,11 @@ jobs:
         run: echo "ARTIFACT_IDENTIFIER=0.1.${GITHUB_RUN_NUMBER}_${GITHUB_RUN_ATTEMPT}_${GITHUB_SHA:0:7}" >> $GITHUB_ENV
       - name: Trigger jenkins infra script
         # if: github.ref_name == 'master'
-        env:
-          JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN }}
-          JENKINS_USER: ${{ secrets.JENKINS_USER }}
-          PARAMETER_NAME: ${{ inputs.param }}
-        run: "curl -X POST --user \"$JENKINS_USER\" \
-          'https://build.leanspace.io/jenkins/job/leanspace/job/leanspace-infra/job/master/buildWithParameters' \
-          -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode \
-          \"$PARAMETER_NAME=$ARTIFACT_IDENTIFIER\" --fail-with-body"
+        uses: fjogeleit/http-request-action@v1.8.2
+        with:
+          url: 'https://build.leanspace.io/jenkins/job/leanspace/job/leanspace-infra/job/master/buildWithParameters'
+          method: 'POST'
+          username: ${{ secrets.JENKINS_USER }}
+          password: ${{ secrets.JENKINS_TOKEN }}
+          data: ${{ format('{0}={1}', inputs.param, env.ARTIFACT_IDENTIFIER) }}
+          customHeaders: '{ "Content-Type": "application/x-www-form-urlencoded" }'

--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -20,8 +20,9 @@ jobs:
         # if: github.ref_name == 'master'
         env:
           JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN }}
+          JENKINS_USER: ${{ secrets.JENKINS_USER }}
           PARAMETER_NAME: ${{ inputs.param }}
-        run: "curl --location --request POST 'https://build.leanspace.io/jenkins/job/leanspace/job/leanspace-infra/job/master/buildWithParameters' \
-          --header 'Authorization: Basic $JENKINS_TOKEN' \
-          --header 'Content-Type: application/x-www-form-urlencoded' \
-          --data-urlencode '$PARAMETER_NAME=$ARTIFACT_IDENTIFIER'"
+        run: "curl -X POST --user '$JENKINS_USER:$JENKINS_TOKEN' \
+          'https://build.leanspace.io/jenkins/job/leanspace/job/leanspace-infra/job/master/buildWithParameters' \
+          -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode \
+          '$PARAMETER_NAME=$ARTIFACT_IDENTIFIER'"

--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -22,7 +22,7 @@ jobs:
           JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN }}
           JENKINS_USER: ${{ secrets.JENKINS_USER }}
           PARAMETER_NAME: ${{ inputs.param }}
-        run: "curl -X POST --user '$JENKINS_USER:$JENKINS_TOKEN' \
+        run: "curl -v -X POST --user '${JENKINS_USER}:${JENKINS_TOKEN}' \
           'https://build.leanspace.io/jenkins/job/leanspace/job/leanspace-infra/job/master/buildWithParameters' \
           -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode \
-          '$PARAMETER_NAME=$ARTIFACT_IDENTIFIER'"
+          '${PARAMETER_NAME}=${ARTIFACT_IDENTIFIER}'"

--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set env
         run: echo "ARTIFACT_IDENTIFIER=0.1.${GITHUB_RUN_NUMBER}_${GITHUB_RUN_ATTEMPT}_${GITHUB_SHA:0:7}" >> $GITHUB_ENV
       - name: Trigger jenkins infra script
-        if: github.ref_name == 'master'
+        # if: github.ref_name == 'master'
         env:
           JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN }}
           JENKINS_USER: ${{ secrets.JENKINS_USER }}

--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set env
         run: echo "ARTIFACT_IDENTIFIER=0.1.${GITHUB_RUN_NUMBER}_${GITHUB_RUN_ATTEMPT}_${GITHUB_SHA:0:7}" >> $GITHUB_ENV
       - name: Trigger jenkins infra script
-        # if: github.ref_name == 'master'
+        if: github.ref_name == 'master'
         uses: fjogeleit/http-request-action@v1.8.2
         with:
           url: 'https://build.leanspace.io/jenkins/job/leanspace/job/leanspace-infra/job/master/buildWithParameters'

--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -17,8 +17,7 @@ jobs:
       - name: Set env
         run: echo "ARTIFACT_IDENTIFIER=0.1.${GITHUB_RUN_NUMBER}_${GITHUB_RUN_ATTEMPT}_${GITHUB_SHA:0:7}" >> $GITHUB_ENV
       - name: Trigger jenkins infra script
-        if: github.ref_name == 'master'
-        uses: toptal/jenkins-job-trigger-action@master
+        # if: github.ref_name == 'master'
         env:
           JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN }}
           PARAMETER_NAME: ${{ inputs.param }}

--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -22,7 +22,7 @@ jobs:
           JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN }}
           JENKINS_USER: ${{ secrets.JENKINS_USER }}
           PARAMETER_NAME: ${{ inputs.param }}
-        run: "curl -v -X POST --user '${JENKINS_USER}:${JENKINS_TOKEN}' \
+        run: "curl -v -X POST --user \"$JENKINS_USER:$JENKINS_TOKEN\" \
           'https://build.leanspace.io/jenkins/job/leanspace/job/leanspace-infra/job/master/buildWithParameters' \
           -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode \
-          '${PARAMETER_NAME}=${ARTIFACT_IDENTIFIER}'"
+          \"$PARAMETER_NAME=$ARTIFACT_IDENTIFIER\""


### PR DESCRIPTION
If there is a current build on the Jenkins platform the `toptal/jenkins-job-trigger-action@master` action enters the run in a pending queue but times out instead of succeeding without waiting a response.
This workaround runs a request directly with the appropiate credentials.