### PR TITLE
set inline properties for jenkins compatibility

### DIFF
--- a/.github/workflows/sonar-nexus-deploy.yml
+++ b/.github/workflows/sonar-nexus-deploy.yml
@@ -60,7 +60,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -gs config-files/maven/nexus-config.xml -Dsonar.projectKey=leanspace_${{ github.event.repository.name }}
+      run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -gs config-files/maven/nexus-config.xml -Dsonar.projectKey=leanspace_${{ github.event.repository.name }} -Dsonar.organization=leanspace -Dsonar.host.url=https://sonarcloud.io
     - name: Set env
       run: echo "ARTIFACT_IDENTIFIER=0.1.${GITHUB_RUN_NUMBER}_${GITHUB_RUN_ATTEMPT}_${GITHUB_SHA:0:7}" >> $GITHUB_ENV
     - name: Deploy to nexus


### PR DESCRIPTION
The [leanspace-parent]([leanspace-parent](https://github.com/leanspace/leanspace-parent)) `pom.xml` contains two properties used in the SonarCloud configuration. Since this file is imported by repositories on bitbucket that do not use SonarCloud it conflicts with sonar configuration.
For this, the properties are set at the maven call and removed from the parent pom.