### PR TITLE
Option to skip integration tests

### DIFF
--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -8,6 +8,10 @@ on:
       version-identifier:
         required: true
         type: string
+      run-tests:
+        required: false
+        type: boolean
+        default: true
     secrets:
       JENKINS_USER:
         required: true
@@ -20,9 +24,9 @@ jobs:
       - name: Trigger jenkins infra script
         uses: fjogeleit/http-request-action@v1.8.2
         with:
-          url: 'https://build.leanspace.io/jenkins/job/leanspace/job/leanspace-infra/job/master/buildWithParameters'
-          method: 'POST'
+          url: "https://build.leanspace.io/jenkins/job/leanspace/job/leanspace-infra/job/master/buildWithParameters"
+          method: "POST"
           username: ${{ secrets.JENKINS_USER }}
           password: ${{ secrets.JENKINS_TOKEN }}
-          data: ${{ format('{0}={1}', inputs.project-code, inputs.version-identifier) }}
+          data: ${{ format('{0}={1}&runIntegrationTests={2}', inputs.project-code, inputs.version-identifier, inputs.run-tests) }}
           customHeaders: '{ "Content-Type": "application/x-www-form-urlencoded" }'


### PR DESCRIPTION
Note that the target of this PR is the v1 branch/PR, not master. I would like this to be part of v1, but it's not a breaking change anyway.

When deploying the UI and the docs, we don't need to run the integration tests. I added this as an optional workflow input so that we can control which repo runs or doesn't run tests without editing the workflow, but we could also hardcode the list of projects here.

