### PR TITLE
SDEVOPS-84: Github deployments

### DIFF
--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -27,7 +27,7 @@ jobs:
           auto_merge: false
           environment: development
         env:
-          GITHUB_TOKEN: ${{ secrets.LEANSPACE_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Deployment outputs
         run: |
           echo ${{ steps.deployment.outputs.deployment_id }}

--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -20,8 +20,19 @@ on:
 jobs:
   infra:
     runs-on: ubuntu-latest
-    environment: development
     steps:
+      - uses: avakar/create-deployment@v1
+        id: deployment
+        with:
+          auto_merge: false
+          environment: development
+        env:
+          GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+      - name: Deployment outputs
+        run: |
+          echo ${{ steps.deployment.outputs.deployment_id }}
+          echo ${{ steps.deployment.outputs.deployment_url }}
+          echo ${{ steps.deployment.outputs.statuses_url }}
       - name: Trigger jenkins infra script
         uses: fjogeleit/http-request-action@v1.8.2
         with:

--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           auto_merge: false
+          required_contexts: []
           environment: development
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -30,11 +30,14 @@ jobs:
           environment: development
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Deployment outputs
-        run: |
-          echo ${{ steps.deployment.outputs.deployment_id }}
-          echo ${{ steps.deployment.outputs.deployment_url }}
-          echo ${{ steps.deployment.outputs.statuses_url }}
+      - uses: avakar/set-deployment-status@v1
+        with:
+          state: in_progress
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          auto_inactive: false
+          description: "Develop deployment in progress"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Trigger jenkins infra script
         uses: fjogeleit/http-request-action@v1.8.2
         with:
@@ -42,5 +45,5 @@ jobs:
           method: "POST"
           username: ${{ secrets.JENKINS_USER }}
           password: ${{ secrets.JENKINS_TOKEN }}
-          data: ${{ format('{0}={1}&runIntegrationTests={2}', inputs.project-code, inputs.version-identifier, inputs.run-tests) }}
+          data: ${{ format('{0}={1}&runIntegrationTests={2}&deploymentId={3}', inputs.project-code, inputs.version-identifier, inputs.run-tests, steps.deployment.outputs.deployment_id) }}
           customHeaders: '{ "Content-Type": "application/x-www-form-urlencoded" }'

--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: avakar/create-deployment@v1
         id: deployment
         with:
+          ref: ${{ github.head_ref }}
           auto_merge: false
           environment: development
         env:

--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Trigger jenkins infra script
         uses: fjogeleit/http-request-action@v1.8.2
         with:
-          url: "https://build.leanspace.io/jenkins/job/leanspace/job/leanspace-infra/job/master/buildWithParameters"
+          url: "https://build.leanspace.io/jenkins/job/Leanspace-infra/job/master/buildWithParameters"
           method: "POST"
           username: ${{ secrets.JENKINS_USER }}
           password: ${{ secrets.JENKINS_TOKEN }}

--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           auto_merge: false
-          required_contexts: []
+          required_contexts: ''
           environment: development
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -20,6 +20,7 @@ on:
 jobs:
   infra:
     runs-on: ubuntu-latest
+    environment: development
     steps:
       - name: Trigger jenkins infra script
         uses: fjogeleit/http-request-action@v1.8.2

--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -27,7 +27,7 @@ jobs:
           auto_merge: false
           environment: development
         env:
-          GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.LEANSPACE_BOT_TOKEN }}
       - name: Deployment outputs
         run: |
           echo ${{ steps.deployment.outputs.deployment_id }}

--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -30,14 +30,6 @@ jobs:
           environment: development
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: avakar/set-deployment-status@v1
-        with:
-          state: in_progress
-          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          auto_inactive: false
-          description: "Develop deployment in progress"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Trigger jenkins infra script
         uses: fjogeleit/http-request-action@v1.8.2
         with:
@@ -47,3 +39,11 @@ jobs:
           password: ${{ secrets.JENKINS_TOKEN }}
           data: ${{ format('{0}={1}&runIntegrationTests={2}&deploymentId={3}', inputs.project-code, inputs.version-identifier, inputs.run-tests, steps.deployment.outputs.deployment_id) }}
           customHeaders: '{ "Content-Type": "application/x-www-form-urlencoded" }'
+      - uses: avakar/set-deployment-status@v1
+        with:
+          state: in_progress
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          auto_inactive: false
+          description: "Develop deployment in progress"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
To add more visibility on Github to the status of the Jenkins deployments we added the ability to create [Github deployments](https://docs.github.com/en/rest/deployments/deployments) (An example [here](https://github.com/leanspace/lambda-metrics-ingestion-processing/deployments/activity_log?environment=development)) when triggering Jenkins' leanspace-infra, once finished the Jenkins pipeline, it will set the status of the deployment to success or failure accordingly https://bitbucket.org/leanspace/leanspace-infra/pull-requests/402.

This change makes use of the Jenkins pipeline triggered from Github so it will not be applied before the repository migration 🥲  https://github.com/leanspace/leanspace-infra/pull/1 