### PR TITLE
Add version number to deployment payload

### DIFF
--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -26,8 +26,9 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           auto_merge: false
-          required_contexts: ''
+          required_contexts: ""
           environment: development
+          payload: ${{ format('{{ "version"{0} "{1}" }}', ':', inputs.version-identifier) }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Trigger jenkins infra script


### PR DESCRIPTION
Adding the version number in the payload of the deployment lets us retrieve it in the post-deployment events.

I'm not 100% sure about the format though :/ I halfway expect the string not to be interpolated, but I can't find a good example of injecting a variable inside a json string.