### PR TITLE
Create releases

### DIFF
--- a/.github/workflows/post-deployment.yml
+++ b/.github/workflows/post-deployment.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           name: "${{ env.repo }}:${{ github.event.deployment.payload.version }}"
           tag_name: ${{ github.event.deployment.payload.version }}
-          repository: leanspace/backend-env-poc #this should be replaced with leanspace/releases c:
-          target_commitish: master
+          repository: leanspace/releases
+          target_commitish: main
           token: ${{ secrets.LEANSPACE_BOT_TOKEN }}
           body: Successful deployment to dev of repository ${{ env.repo }} with version ${{ github.event.deployment.payload.version }}

--- a/.github/workflows/post-deployment.yml
+++ b/.github/workflows/post-deployment.yml
@@ -5,23 +5,41 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Repository identifier and platform identifier
         run: |
           echo "repo=$(basename ${{ github.event.repository.name }})" | tee -a $GITHUB_ENV
-          echo "platform_version=$(echo ${{ github.event.deployment_status.description }} | cut -d ':' -f1)" | tee -a $GITHUB_ENV
-      - name: Create a release
+          version=$(echo ${{ github.event.deployment_status.description }} | cut -d ':' -f1)
+          echo "platform_version=$version" | tee -a $GITHUB_ENV
+          echo "jenkins_job=$(echo $version | cut -d '_' -f1 | cut -d '.' -f3)" | tee -a $GITHUB_ENV
+         
+      - name: Service Release
         uses: softprops/action-gh-release@v1
         with:
           name: ${{ github.event.deployment.payload.version }}
           tag_name: ${{ github.event.deployment.payload.version }}
           target_commitish: ${{ github.event.deployment.sha }}
           body: Successful deployment to dev of version ${{ github.event.deployment.payload.version }} with platform version ${{ env.platform_version }}
-      - name: Releases repo
-        uses: softprops/action-gh-release@v1
+      
+      - name: Get artifact from Jenkins build
+        id: jenkins
+        uses: fjogeleit/http-request-action@v1.8.2
         with:
-          name: "${{ env.repo }}:${{ github.event.deployment.payload.version }}"
-          tag_name: ${{ github.event.deployment.payload.version }}
-          repository: leanspace/releases
-          target_commitish: main
-          token: ${{ secrets.LEANSPACE_BOT_TOKEN }}
-          body: Successful deployment to dev ${{ env.platform_version }} of repository ${{ env.repo }} with version ${{ github.event.deployment.payload.version }}
+          url: "https://build.leanspace.io/jenkins/job/Leanspace-infra/job/master/${{ env.jenkins_job }}/artifact/platformVersion.json"
+          method: "GET"
+          username: ${{ secrets.JENKINS_USER }}
+          password: ${{ secrets.JENKINS_TOKEN }}
+          customHeaders: '{ "Content-Type": "application/x-www-form-urlencoded" }'
+
+      - name: Output of request
+        run: echo ${{ steps.jenkins.outputs.response }}
+      # - name: Platform Release
+      #   uses: softprops/action-gh-release@v1
+      #   with:
+      #     name: "${{ env.platform_version }}"
+      #     tag_name: ${{ github.event.deployment.payload.version }}
+      #     repository: leanspace/releases
+      #     target_commitish: main
+      #     token: ${{ secrets.LEANSPACE_BOT_TOKEN }}
+      #     body: Successful deployment to dev ${{ env.platform_version }} of repository ${{ env.repo }} with version ${{ github.event.deployment.payload.version }}
+      #     files: 

--- a/.github/workflows/post-deployment.yml
+++ b/.github/workflows/post-deployment.yml
@@ -4,8 +4,6 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-
       - name: Repository identifier and platform identifier
         run: |
           echo "repo=$(basename ${{ github.event.repository.name }})" | tee -a $GITHUB_ENV

--- a/.github/workflows/post-deployment.yml
+++ b/.github/workflows/post-deployment.yml
@@ -6,14 +6,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Repository ID
-        run: echo "repo=$(basename ${{ github.event.repository.name }})" | tee -a $GITHUB_ENV
+        run: |
+          echo "repo=$(basename ${{ github.event.repository.name }})" | tee -a $GITHUB_ENV
+          echo "platform_version=$(echo ${{ github.event.deployment_status.description }} | cut -d ':' -f1)" | tee -a $GITHUB_ENV
       - name: Create a release
         uses: softprops/action-gh-release@v1
         with:
           name: ${{ github.event.deployment.payload.version }}
           tag_name: ${{ github.event.deployment.payload.version }}
           target_commitish: ${{ github.event.deployment.sha }}
-          body: ${{ github.event.deployment_status.description }}
+          body: Successful deployment to dev of version ${{ github.event.deployment.payload.version }} with platform version ${{ env.platform_version }}
       - name: Releases repo
         uses: softprops/action-gh-release@v1
         with:
@@ -22,4 +24,4 @@ jobs:
           repository: leanspace/releases
           target_commitish: main
           token: ${{ secrets.LEANSPACE_BOT_TOKEN }}
-          body: Successful deployment to dev of repository ${{ env.repo }} with version ${{ github.event.deployment.payload.version }}
+          body: Successful deployment to dev ${{ env.platform_version }} of repository ${{ env.repo }} with version ${{ github.event.deployment.payload.version }}

--- a/.github/workflows/post-deployment.yml
+++ b/.github/workflows/post-deployment.yml
@@ -31,15 +31,16 @@ jobs:
           password: ${{ secrets.JENKINS_TOKEN }}
           customHeaders: '{ "Content-Type": "application/x-www-form-urlencoded" }'
 
-      - name: Output of request
-        run: echo ${{ steps.jenkins.outputs.response }}
-      # - name: Platform Release
-      #   uses: softprops/action-gh-release@v1
-      #   with:
-      #     name: "${{ env.platform_version }}"
-      #     tag_name: ${{ github.event.deployment.payload.version }}
-      #     repository: leanspace/releases
-      #     target_commitish: main
-      #     token: ${{ secrets.LEANSPACE_BOT_TOKEN }}
-      #     body: Successful deployment to dev ${{ env.platform_version }} of repository ${{ env.repo }} with version ${{ github.event.deployment.payload.version }}
-      #     files: 
+      - name: Store platform versions
+        run: echo ${{ steps.jenkins.outputs.response }} >> platformVersion.json
+
+      - name: Platform Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ env.platform_version }}
+          tag_name: ${{ env.platform_version }}
+          repository: leanspace/releases
+          target_commitish: main
+          token: ${{ secrets.LEANSPACE_BOT_TOKEN }}
+          body: Successful deployment to develop ${{ env.platform_version }} of repository ${{ env.repo }} with version ${{ github.event.deployment.payload.version }}
+          files: platformVersion.json

--- a/.github/workflows/post-deployment.yml
+++ b/.github/workflows/post-deployment.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Repository ID
+      - name: Repository identifier and platform identifier
         run: |
           echo "repo=$(basename ${{ github.event.repository.name }})" | tee -a $GITHUB_ENV
           echo "platform_version=$(echo ${{ github.event.deployment_status.description }} | cut -d ':' -f1)" | tee -a $GITHUB_ENV

--- a/.github/workflows/post-deployment.yml
+++ b/.github/workflows/post-deployment.yml
@@ -1,0 +1,25 @@
+name: Post Deployment Actions
+on: workflow_call
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Repository ID
+        run: echo "repo=$(basename ${{ github.event.repository.name }})" | tee -a $GITHUB_ENV
+      - name: Create a release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ github.event.deployment.payload.version }}
+          tag_name: ${{ github.event.deployment.payload.version }}
+          target_commitish: ${{ github.event.deployment.sha }}
+          body: ${{ github.event.deployment_status.description }}
+      - name: Releases repo
+        uses: softprops/action-gh-release@v1
+        with:
+          name: "${{ env.repo }}:${{ github.event.deployment.payload.version }}"
+          tag_name: ${{ github.event.deployment.payload.version }}
+          repository: leanspace/backend-env-poc #this should be replaced with leanspace/releases c:
+          target_commitish: master
+          token: ${{ secrets.LEANSPACE_BOT_TOKEN }}
+          body: Successful deployment to dev of repository ${{ env.repo }} with version ${{ github.event.deployment.payload.version }}


### PR DESCRIPTION
When a deployment to dev has finished with a successful status a workflow located in each repo will be triggered to:

1. Create a release in https://github.com/leanspace/releases main branch, with the Jenkins' build identifier as tag and release name, and add as an artifact the platform versions deployed on that build. [example](https://github.com/leanspace/releases/releases)

2. Create a release in its own repo associated with the commit that triggered the deployment, with the same name and tag: {version identifier} [example](https://github.com/leanspace/lambda-metrics-ingestion-processing/releases/tag/0.1.45_3_0b499e7)

The idea of the second point is to have easy access to the version identifiers that were deployed inside the self repository.
