### PR TITLE
Add post-deployment notifications and saves

### DIFF
--- a/.github/workflows/post-deployment.yml
+++ b/.github/workflows/post-deployment.yml
@@ -3,6 +3,7 @@ on: workflow_call
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: github.event.deployment_status.state == 'success'
     steps:
       - name: Repository identifier and platform identifier
         run: |
@@ -10,7 +11,7 @@ jobs:
           version=$(echo ${{ github.event.deployment_status.description }} | cut -d ':' -f1)
           echo "platform_version=$version" | tee -a $GITHUB_ENV
           echo "jenkins_job=$(echo $version | cut -d '_' -f1 | cut -d '.' -f3)" | tee -a $GITHUB_ENV
-         
+
       - name: Service Release
         uses: softprops/action-gh-release@v1
         with:
@@ -18,7 +19,7 @@ jobs:
           tag_name: ${{ github.event.deployment.payload.version }}
           target_commitish: ${{ github.event.deployment.sha }}
           body: Successful deployment to dev of version ${{ github.event.deployment.payload.version }} with platform version ${{ env.platform_version }}
-      
+
       - name: Get artifact from Jenkins build
         id: jenkins
         uses: fjogeleit/http-request-action@v1.8.2
@@ -42,3 +43,45 @@ jobs:
           token: ${{ secrets.LEANSPACE_BOT_TOKEN }}
           body: Successful deployment to develop ${{ env.platform_version }} of repository ${{ env.repo }} with version ${{ github.event.deployment.payload.version }}
           files: platformVersion.json
+
+  notify-pr:
+    runs-on: ubuntu-latest
+    name: Notify PR
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.LEANSPACE_BOT_TOKEN }}
+          script: |
+            const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.payload.deployment.sha
+            });
+            await Promise.all(prs.data.map(pullRequest => 
+              github.rest.issues.createComment({
+                issue_number: pullRequest.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: context.payload.deployment_status.state === 'success' ? 
+                      'The change were successfully deployed to the develop environment 🎉' : 
+                      `Deployment failed ❌ 
+                      [Click here to access the deployment logs](${context.payload.deployment_status.log_url}) and decide if you need to fix something or restart the deployment.`
+              })
+            ))
+
+  parameter-store-update:
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ format('arn:aws:iam::{0}:role/GithubActionsParameterStoreAccess', secrets.ACCOUNT_ID) }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Add version of build to parameter store
+        env:
+          PARAMETER: ${{ format('/leanspace/build/{0}', github.event.repository.name) }}
+          VALUE: ${{ github.event.deployment.payload.version }}
+        run: aws ssm put-parameter --name $PARAMETER --value $VALUE --overwrite


### PR DESCRIPTION
This PR adds 2 completely distinct actions to the post-deployment steps:

1. Add a comment on the PR that triggered the deployment to notify of the result (it will replace https://github.com/leanspace/leanspace-infra/blob/master/Jenkinsfile#L572)
2. Save the latest valid version of a service to the parameter store (it will replace https://github.com/leanspace/leanspace-infra/blob/master/Jenkinsfile#L571)